### PR TITLE
Add sample API_KEY build variable to gradle config

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ ___
 * Internet
 * Network State
 
+## Building the Application
+Get your API Key from newspi.org and then place the value inside app/build.gradle file.
+Modify the API_KEY entry in it.
 
 ## Screenshots
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,6 +17,8 @@ android {
         versionCode 1
         versionName "1.0"
 
+        buildConfigField "String", "API_KEY", "\"<Enter your API Key here>\""
+
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 


### PR DESCRIPTION
By default the app build fails, since there is no existence fo API_KEY variable in the gradle files. In order to avoid this, we should add a sample variable which should be present there for reference to anyone who is going to checkout the source code;